### PR TITLE
Improve `useIsMobile` with `matchMedia` and SSR-safe initial state

### DIFF
--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -55,6 +55,10 @@ export function Nav() {
 
   const segment = useSelectedLayoutSegments();
 
+  if (isMobile === null) {
+    return null;
+  }
+
   return (
     <div
       className={clsx({

--- a/components/resume/resume-description.tsx
+++ b/components/resume/resume-description.tsx
@@ -15,6 +15,10 @@ export const ResumeDescription = (props: Props) => {
 
   const isMobile = useIsMobile();
 
+  if (isMobile === null) {
+    return <SkeletonCard />;
+  }
+
   const totalPages =
     !isMobile && allDesc && allDesc.length > 0
       ? Math.ceil(allDesc.length / 4)

--- a/hooks/use-is-mobile.tsx
+++ b/hooks/use-is-mobile.tsx
@@ -1,16 +1,26 @@
 import { useEffect, useState } from "react";
 
 export function useIsMobile(breakpoint = 768) {
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState<boolean | null>(null);
 
   useEffect(() => {
-    const check = () => {
-      setIsMobile(window.innerWidth < breakpoint);
+    const mediaQuery = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches);
     };
 
-    check();
-    window.addEventListener("resize", check);
-    return () => window.removeEventListener("resize", check);
+    // Initialize once on mount / breakpoint change
+    setIsMobile(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    // Fallback for older browsers
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
   }, [breakpoint]);
 
   return isMobile;


### PR DESCRIPTION
### Motivation
- Reduce frequent state updates caused by `resize` events during drag-resize by using `matchMedia` change events.
- Avoid hydration flicker in SSR (Next.js) by representing the pre-mount viewport as an unknown state so initial renders don’t assume desktop/mobile.

### Description
- Rewrote `useIsMobile` to use `window.matchMedia('(max-width: ...px)')` and listen to `change` events instead of `resize` events.
- Changed the hook state to `boolean | null` and initialize it on mount with `mediaQuery.matches` so pre-mount state is `null` (unknown).
- Added a compatibility fallback using `addListener`/`removeListener` for older browsers.
- Updated `Nav` to return `null` when `isMobile === null` and updated `ResumeDescription` to render `SkeletonCard` while `isMobile === null` to avoid hydration/layout flashes.

### Testing
- Ran linting with `npm run lint` (Next.js ESLint) and it completed with no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4ef66d5c832b9f7429dc4958d331)