### PR TITLE
Use backend action helpers for data fetching instead of inline fetch calls

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,22 +5,14 @@ import HomeMain from "@/components/main/home-main";
 import HomeParticles from "@/components/main/home-particles";
 import HomeSkills from "@/components/main/home-skills";
 import ScrollTrackerNav from "@/components/main/scroll-tracker-nav";
-import { apiUrl } from "@/lib/utils";
+import { getMainData, getSkillData } from "@/backend/main-actions";
 import { Main, Skill } from "@/types/main";
 import React from "react";
 
 export default async function Home() {
-  let main: Main[] = [];
-  const res = await fetch(`${apiUrl}/api/main`, {
-    next: { revalidate: 60 }, // 60초마다 재생성
-  });
-  main = await res.json();
+  const main: Main[] = await getMainData();
 
-  let skill: Skill[] = [];
-  const response = await fetch(`${apiUrl}/api/skill`, {
-    next: { revalidate: 60 }, // 60초마다 재생성
-  });
-  skill = await response.json();
+  const skill: Skill[] = await getSkillData();
 
   return (
     <div className="relative z-30 bg-darkOnly-bg h-full px-4 py-4 lg:py-[80px] lg:max-w-[1280px] mx-auto">

--- a/app/resume/[slug]/page.tsx
+++ b/app/resume/[slug]/page.tsx
@@ -1,8 +1,13 @@
 import { ResumeContents } from "@/components/resume/resume-contents";
 import { TitlesDescriptions } from "@/components/resume/titles-descriptions";
-import { apiUrl } from "@/lib/utils";
 //import { Metadata, ResolvingMetadata } from "next";
 import React from "react";
+import {
+  getCertificatesData,
+  getDescriptionsData,
+  getEducationsData,
+  getExperiencesData,
+} from "@/backend/resume-actions";
 
 import {
   Certificate,
@@ -53,31 +58,18 @@ export default async function Page(
 
   const currentPage = Number(searchParams?.page) || 1;
 
-  let AllDescription: Description[] = [];
-  const res = await fetch(`${apiUrl}/api/resume/descriptions`, {
-    next: { revalidate: 60 }, // 60초마다 재생성
-  });
-  AllDescription = await res.json();
+  const AllDescription: Description[] = await getDescriptionsData();
 
   let data: Description[] | Education[] | Experience[] | Certificate[] = [];
 
   if (slug === "certificates") {
-    const response = await fetch(`${apiUrl}/api/resume/certificates`, {
-      next: { revalidate: 60 }, // 60초마다 재생성
-    });
-    data = await response.json();
+    data = await getCertificatesData();
   } else if (slug === "descriptions") {
     data = await fetchProjectsPages(currentPage);
   } else if (slug === "experiences") {
-    const response = await fetch(`${apiUrl}/api/resume/experiences`, {
-      next: { revalidate: 60 }, // 60초마다 재생성
-    });
-    data = await response.json();
+    data = await getExperiencesData();
   } else if (slug === "educations") {
-    const response = await fetch(`${apiUrl}/api/resume/educations`, {
-      next: { revalidate: 60 }, // 60초마다 재생성
-    });
-    data = await response.json();
+    data = await getEducationsData();
   }
 
   return (

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 import type { Work } from "@/types/work";
 import { Suspense } from "react";
 import { SkeletonSlide } from "@/components/ui/skeleton-slide";
-import { apiUrl } from "@/lib/utils";
+import { getWorksData } from "@/backend/work-actions";
 
 export const metadata: Metadata = {
   title: "작업물",
@@ -12,11 +12,7 @@ export const metadata: Metadata = {
 };
 
 export default async function Work() {
-  let data: Work[] = [];
-  const res = await fetch(`${apiUrl}/api/work`, {
-    next: { revalidate: 60 }, // 60초마다 재생성
-  });
-  data = await res.json();
+  const data: Work[] = await getWorksData();
 
   return (
     <>


### PR DESCRIPTION
### Motivation
- Centralize and reuse server-side data fetching by replacing ad-hoc `fetch` calls and `apiUrl` usage with backend action helper functions.

### Description
- In `app/page.tsx` replaced inline fetches with `getMainData` and `getSkillData` from `@/backend/main-actions` and removed the `apiUrl` import.   
- In `app/resume/[slug]/page.tsx` replaced multiple fetches with `getCertificatesData`, `getDescriptionsData`, `getEducationsData`, and `getExperiencesData` from `@/backend/resume-actions` and removed the `apiUrl` import.   
- In `app/work/page.tsx` replaced the inline fetch with `getWorksData` from `@/backend/work-actions` and removed the `apiUrl` import.   
- Kept existing render logic and TypeScript types intact while removing fetch boilerplate and centralizing data access.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db57f40d8c832b836ec81c80252295)