### PR TITLE
Add caching, queryable resume API, React Query provider, and carousel state store

### DIFF
--- a/app/api/resume/descriptions/route.ts
+++ b/app/api/resume/descriptions/route.ts
@@ -1,6 +1,25 @@
+import { fetchDescriptionsByQuery } from "@/backend/fetch-data";
 import { getDescriptionsData } from "@/backend/resume-actions";
 import { withApiHandler } from "@/lib/with-api-handler";
+import { NextRequest } from "next/server";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const query = searchParams.get("query") ?? "";
+  const page = Number(searchParams.get("page") ?? "1");
+  const pageSize = Number(searchParams.get("pageSize") ?? "4");
+
+  if (searchParams.has("page") || searchParams.has("query")) {
+    return withApiHandler(
+      () =>
+        fetchDescriptionsByQuery({
+          currentPage: Number.isNaN(page) || page < 1 ? 1 : page,
+          pageSize: Number.isNaN(pageSize) || pageSize < 1 ? 4 : pageSize,
+          query,
+        }),
+      "Error fetching paginated description data:"
+    );
+  }
+
   return withApiHandler(getDescriptionsData, "Error fetching description data:");
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "@/styles/globals.css";
 import { notoSansKR } from "@/styles/fonts";
 import { Header } from "@/components/header";
+import { QueryProvider } from "@/components/providers/query-provider";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://galaxychoiportfolio.vercel.app"),
@@ -32,8 +33,10 @@ export default function RootLayout({
       <body
         className={`${notoSansKR.className} antialiased w-full overflow-x-hidden bg-bg-default`}
       >
-        <Header />
-        {children}
+        <QueryProvider>
+          <Header />
+          {children}
+        </QueryProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,22 +5,14 @@ import HomeMain from "@/components/main/home-main";
 import HomeParticles from "@/components/main/home-particles";
 import HomeSkills from "@/components/main/home-skills";
 import ScrollTrackerNav from "@/components/main/scroll-tracker-nav";
-import { apiUrl } from "@/lib/utils";
+import { getMainData, getSkillData } from "@/backend/main-actions";
 import { Main, Skill } from "@/types/main";
 import React from "react";
 
 export default async function Home() {
-  let main: Main[] = [];
-  const res = await fetch(`${apiUrl}/api/main`, {
-    next: { revalidate: 60 }, // 60초마다 재생성
-  });
-  main = await res.json();
+  const main: Main[] = await getMainData();
 
-  let skill: Skill[] = [];
-  const response = await fetch(`${apiUrl}/api/skill`, {
-    next: { revalidate: 60 }, // 60초마다 재생성
-  });
-  skill = await response.json();
+  const skill: Skill[] = await getSkillData();
 
   return (
     <div className="relative z-30 bg-darkOnly-bg h-full px-4 py-4 lg:py-[80px] lg:max-w-[1280px] mx-auto">

--- a/app/resume/[slug]/page.tsx
+++ b/app/resume/[slug]/page.tsx
@@ -1,8 +1,13 @@
 import { ResumeContents } from "@/components/resume/resume-contents";
 import { TitlesDescriptions } from "@/components/resume/titles-descriptions";
-import { apiUrl } from "@/lib/utils";
 //import { Metadata, ResolvingMetadata } from "next";
 import React from "react";
+import {
+  getCertificatesData,
+  getDescriptionsData,
+  getEducationsData,
+  getExperiencesData,
+} from "@/backend/resume-actions";
 
 import {
   Certificate,
@@ -53,31 +58,18 @@ export default async function Page(
 
   const currentPage = Number(searchParams?.page) || 1;
 
-  let AllDescription: Description[] = [];
-  const res = await fetch(`${apiUrl}/api/resume/descriptions`, {
-    next: { revalidate: 60 }, // 60초마다 재생성
-  });
-  AllDescription = await res.json();
+  const AllDescription: Description[] = await getDescriptionsData();
 
   let data: Description[] | Education[] | Experience[] | Certificate[] = [];
 
   if (slug === "certificates") {
-    const response = await fetch(`${apiUrl}/api/resume/certificates`, {
-      next: { revalidate: 60 }, // 60초마다 재생성
-    });
-    data = await response.json();
+    data = await getCertificatesData();
   } else if (slug === "descriptions") {
     data = await fetchProjectsPages(currentPage);
   } else if (slug === "experiences") {
-    const response = await fetch(`${apiUrl}/api/resume/experiences`, {
-      next: { revalidate: 60 }, // 60초마다 재생성
-    });
-    data = await response.json();
+    data = await getExperiencesData();
   } else if (slug === "educations") {
-    const response = await fetch(`${apiUrl}/api/resume/educations`, {
-      next: { revalidate: 60 }, // 60초마다 재생성
-    });
-    data = await response.json();
+    data = await getEducationsData();
   }
 
   return (

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 import type { Work } from "@/types/work";
 import { Suspense } from "react";
 import { SkeletonSlide } from "@/components/ui/skeleton-slide";
-import { apiUrl } from "@/lib/utils";
+import { getWorksData } from "@/backend/work-actions";
 
 export const metadata: Metadata = {
   title: "작업물",
@@ -12,11 +12,7 @@ export const metadata: Metadata = {
 };
 
 export default async function Work() {
-  let data: Work[] = [];
-  const res = await fetch(`${apiUrl}/api/work`, {
-    next: { revalidate: 60 }, // 60초마다 재생성
-  });
-  data = await res.json();
+  const data: Work[] = await getWorksData();
 
   return (
     <>

--- a/backend/fetch-data.ts
+++ b/backend/fetch-data.ts
@@ -7,7 +7,8 @@ import {
 } from "@/types/resume";
 import { Work } from "@/types/work";
 import { sql } from "@vercel/postgres";
-import { unstable_noStore as noStore } from "next/cache";
+import { unstable_cache, unstable_noStore as noStore } from "next/cache";
+import { CACHE_TAGS } from "@/lib/cache-tags";
 
 type ProjectData =
   | Certificate
@@ -152,18 +153,95 @@ export async function fetchProjectById(
 }
 
 const PROJECTS_PER_PAGE = 4;
+export type PaginatedDescriptions = {
+  items: Description[];
+  totalCount: number;
+  totalPages: number;
+  currentPage: number;
+};
 
 export async function fetchProjectsPages(
   currentPage: number
 ): Promise<Description[]> {
-  const offset = (currentPage - 1) * PROJECTS_PER_PAGE;
+  const getCachedProjectsPages = unstable_cache(
+    async (page: number) => {
+      const offset = (page - 1) * PROJECTS_PER_PAGE;
+
+      const { rows }: { rows: Description[] } =
+        await sql`SELECT id, title, date, performance, role, skills FROM descriptions_contents ORDER BY date DESC LIMIT ${PROJECTS_PER_PAGE} OFFSET ${offset};`;
+      return rows;
+    },
+    ["resume-project-pages"],
+    {
+      revalidate: 60,
+      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
+    }
+  );
 
   try {
-    const { rows }: { rows: Description[] } =
-      await sql`SELECT id, title, date, performance, role, skills FROM descriptions_contents ORDER BY date DESC LIMIT ${PROJECTS_PER_PAGE} OFFSET ${offset};`;
-    return rows;
+    return await getCachedProjectsPages(currentPage);
   } catch (error) {
     throw new Error("Failed to fetch getDescriptionsData data");
+  }
+}
+
+export async function fetchDescriptionsByQuery({
+  currentPage,
+  pageSize = PROJECTS_PER_PAGE,
+  query,
+}: {
+  currentPage: number;
+  pageSize?: number;
+  query?: string;
+}): Promise<PaginatedDescriptions> {
+  const getCachedDescriptionsByQuery = unstable_cache(
+    async (page: number, limit: number, searchQuery: string) => {
+      const offset = (page - 1) * limit;
+      const term = `%${searchQuery}%`;
+
+      const { rows: countRows } = await sql<{ count: string }>`
+        SELECT COUNT(*)::text AS count
+        FROM descriptions_contents
+        WHERE
+          (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term});
+      `;
+
+      const count = countRows[0]?.count ?? "0";
+      const totalCount = Number(count ?? "0");
+      const totalPages = Math.max(1, Math.ceil(totalCount / limit));
+
+      const { rows }: { rows: Description[] } = await sql`
+        SELECT id, title, date, performance, role, skills
+        FROM descriptions_contents
+        WHERE
+          (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term})
+        ORDER BY date DESC
+        LIMIT ${limit}
+        OFFSET ${offset};
+      `;
+
+      return {
+        items: rows,
+        totalCount,
+        totalPages,
+        currentPage: page,
+      };
+    },
+    ["resume-descriptions-by-query"],
+    {
+      revalidate: 60,
+      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
+    }
+  );
+
+  try {
+    return await getCachedDescriptionsByQuery(
+      currentPage,
+      pageSize,
+      query?.trim() ?? ""
+    );
+  } catch (error) {
+    throw new Error("Failed to fetch descriptions with query");
   }
 }
 

--- a/backend/main-actions.ts
+++ b/backend/main-actions.ts
@@ -1,17 +1,27 @@
 "use server";
 
 import { sql } from "@vercel/postgres";
+import { unstable_cache } from "next/cache";
 import { Main, Skill } from "@/types/main";
+import { CACHE_TAGS } from "@/lib/cache-tags";
 
 /**
  * Main
  */
 
 export async function getMainData(): Promise<Main[]> {
+  const getCachedMainData = unstable_cache(
+    async () => {
+      const { rows }: { rows: Main[] } =
+        await sql`SELECT id, title, content1, content2, description, description2, description3, button, path, alt, url FROM main_contents ORDER BY path ASC;`;
+      return rows;
+    },
+    ["main-data"],
+    { revalidate: 60, tags: [CACHE_TAGS.main] }
+  );
+
   try {
-    const { rows }: { rows: Main[] } =
-      await sql`SELECT id, title, content1, content2, description, description2, description3, button, path, alt, url FROM main_contents ORDER BY path ASC;`;
-    return rows;
+    return await getCachedMainData();
   } catch (error) {
     console.log(error);
     throw new Error("Failed to fetch getMainData data");
@@ -23,10 +33,18 @@ export async function getMainData(): Promise<Main[]> {
  */
 
 export async function getSkillData(): Promise<Skill[]> {
+  const getCachedSkillData = unstable_cache(
+    async () => {
+      const { rows }: { rows: Skill[] } =
+        await sql`SELECT id, color::int, skills::int, name, angle::int FROM skill_contents ORDER BY created_at ASC;`;
+      return rows;
+    },
+    ["skill-data"],
+    { revalidate: 60, tags: [CACHE_TAGS.skill] }
+  );
+
   try {
-    const { rows }: { rows: Skill[] } =
-      await sql`SELECT id, color::int, skills::int, name, angle::int FROM skill_contents ORDER BY created_at ASC;`;
-    return rows;
+    return await getCachedSkillData();
   } catch (error) {
     throw new Error("Failed to fetch getSkillData data");
   }

--- a/backend/resume-actions.ts
+++ b/backend/resume-actions.ts
@@ -1,51 +1,97 @@
 "use server";
 
 import { sql } from "@vercel/postgres";
+import { unstable_cache } from "next/cache";
 import {
   Certificate,
   Description,
   Experience,
   Education,
 } from "@/types/resume";
+import { CACHE_TAGS } from "@/lib/cache-tags";
 
 export async function getCertificatesData(): Promise<Certificate[]> {
+  const getCachedCertificatesData = unstable_cache(
+    async () => {
+      const { rows }: { rows: Certificate[] } = await sql`
+          SELECT id, date, name, authority
+          FROM certificates_contents 
+          ORDER BY date DESC;
+        `;
+      return rows;
+    },
+    ["resume-certificates-data"],
+    {
+      revalidate: 60,
+      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.certificates],
+    }
+  );
+
   try {
-    const { rows }: { rows: Certificate[] } = await sql`
-        SELECT id, date, name, authority
-        FROM certificates_contents 
-        ORDER BY date DESC;
-      `;
-    return rows;
+    return await getCachedCertificatesData();
   } catch (error) {
     throw new Error("Failed to fetch getCertificatesData data");
   }
 }
 
 export async function getDescriptionsData(): Promise<Description[]> {
+  const getCachedDescriptionsData = unstable_cache(
+    async () => {
+      const { rows }: { rows: Description[] } =
+        await sql`SELECT id, title, date, performance, role, skills FROM descriptions_contents ORDER BY date DESC ;`;
+      return rows;
+    },
+    ["resume-descriptions-data"],
+    {
+      revalidate: 60,
+      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
+    }
+  );
+
   try {
-    const { rows }: { rows: Description[] } =
-      await sql`SELECT id, title, date, performance, role, skills FROM descriptions_contents ORDER BY date DESC ;`;
-    return rows;
+    return await getCachedDescriptionsData();
   } catch (error) {
     throw new Error("Failed to fetch getDescriptionsData data");
   }
 }
 
 export async function getExperiencesData(): Promise<Experience[]> {
+  const getCachedExperiencesData = unstable_cache(
+    async () => {
+      const { rows }: { rows: Experience[] } =
+        await sql`SELECT id, company, title, date, description FROM experiences_contents ORDER BY date DESC;`;
+      return rows;
+    },
+    ["resume-experiences-data"],
+    {
+      revalidate: 60,
+      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.experiences],
+    }
+  );
+
   try {
-    const { rows }: { rows: Experience[] } =
-      await sql`SELECT id, company, title, date, description FROM experiences_contents ORDER BY date DESC;`;
-    return rows;
+    return await getCachedExperiencesData();
   } catch (error) {
     throw new Error("Failed to fetch getExperiencesData data");
   }
 }
 
 export async function getEducationsData(): Promise<Education[]> {
+  const getCachedEducationsData = unstable_cache(
+    async () => {
+      const { rows }: { rows: Education[] } =
+        await sql`SELECT id, school, degree, institution, date FROM educations_contents ORDER BY date DESC;`;
+      return rows;
+    },
+    ["resume-educations-data"],
+    {
+      revalidate: 60,
+      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.educations],
+    }
+  );
+
   try {
-    const { rows }: { rows: Education[] } =
-      await sql`SELECT id, school, degree, institution, date FROM educations_contents ORDER BY date DESC;`;
-    return rows;
+    return await getCachedEducationsData();
   } catch (error) {
     throw new Error("Failed to fetch getEducationsData data");
   }

--- a/backend/work-actions.ts
+++ b/backend/work-actions.ts
@@ -1,13 +1,23 @@
 "use server";
 
 import { sql } from "@vercel/postgres";
+import { unstable_cache } from "next/cache";
 import { Work } from "@/types/work";
+import { CACHE_TAGS } from "@/lib/cache-tags";
 
 export async function getWorksData(): Promise<Work[]> {
+  const getCachedWorksData = unstable_cache(
+    async () => {
+      const { rows }: { rows: Work[] } =
+        await sql`SELECT id, title, description, skill, path, url, download, git, index FROM works_contents ORDER BY path DESC;`;
+      return rows;
+    },
+    ["works-data"],
+    { revalidate: 60, tags: [CACHE_TAGS.work] }
+  );
+
   try {
-    const { rows }: { rows: Work[] } =
-      await sql`SELECT id, title, description, skill, path, url, download, git, index FROM works_contents ORDER BY path DESC;`;
-    return rows;
+    return await getCachedWorksData();
   } catch (error) {
     throw new Error("Failed to fetch getWorksData data");
   }

--- a/components/providers/query-provider.tsx
+++ b/components/providers/query-provider.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PropsWithChildren, useState } from "react";
+
+export function QueryProvider({ children }: PropsWithChildren) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+            gcTime: 5 * 60 * 1000,
+            retry: 1,
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/components/resume/resume-description.tsx
+++ b/components/resume/resume-description.tsx
@@ -4,6 +4,13 @@ import { BoundaryResume } from "../ui/boundary-resume";
 import Pagination from "../ui/pagination";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { SkeletonCard } from "../ui/skeleton-card";
+import {
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
+import { useDebouncedCallback } from "use-debounce";
+import { useResumeDescriptionsQuery } from "@/hooks/use-resume-descriptions-query";
 
 type Props = {
   data: Description[];
@@ -12,26 +19,69 @@ type Props = {
 
 export const ResumeDescription = (props: Props) => {
   const { data, allDesc } = props;
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   const isMobile = useIsMobile();
+  const currentPage = Number(searchParams.get("page")) || 1;
+  const currentQuery = searchParams.get("query") ?? "";
+
+  const { data: queryData, isLoading } = useResumeDescriptionsQuery({
+    page: currentPage,
+    query: currentQuery,
+    pageSize: 4,
+    initialData: {
+      items: data,
+      totalCount: allDesc?.length ?? data.length,
+      totalPages: Math.max(1, Math.ceil((allDesc?.length ?? data.length) / 4)),
+      currentPage,
+    },
+  });
+
+  const onSearch = useDebouncedCallback((value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (value) {
+      params.set("query", value);
+    } else {
+      params.delete("query");
+    }
+    params.set("page", "1");
+
+    router.replace(`${pathname}?${params.toString()}`);
+  }, 300);
 
   if (isMobile === null) {
     return <SkeletonCard />;
   }
 
-  const totalPages =
-    !isMobile && allDesc && allDesc.length > 0
-      ? Math.ceil(allDesc.length / 4)
-      : 1;
+  const totalPages = !isMobile ? queryData?.totalPages ?? 1 : 1;
 
-  const listData = !isMobile ? data : allDesc;
+  const listData = !isMobile ? queryData?.items ?? [] : allDesc;
 
-  if (!listData || listData.length === 0) {
+  if (isLoading) {
     return <SkeletonCard />;
   }
 
   return (
     <div className="w-full">
+      {!isMobile ? (
+        <div className="mb-4">
+          <input
+            defaultValue={currentQuery}
+            onChange={(e) => onSearch(e.target.value)}
+            placeholder="프로젝트/기술 검색"
+            aria-label="이력 검색"
+            className="w-full h-10 px-3 border border-border rounded-md bg-transparent"
+          />
+        </div>
+      ) : null}
+      {!listData || listData.length === 0 ? (
+        <BoundaryResume>
+          <p>조건에 맞는 이력이 없습니다.</p>
+        </BoundaryResume>
+      ) : null}
       {listData.map((data, index) => (
         <article key={index}>
           <BoundaryResume>

--- a/components/work/multi-carousel.tsx
+++ b/components/work/multi-carousel.tsx
@@ -1,8 +1,9 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useRef } from "react";
 import Carousel from "react-multi-carousel";
 import "react-multi-carousel/lib/styles.css";
+import { useWorkCarouselStore } from "@/stores/work-carousel-store";
 
 const responsive = {
   superLargeDesktop: {
@@ -26,17 +27,12 @@ const responsive = {
 type CustomButtonGroupProps = {
   next: () => void;
   previous: () => void;
-  currentSlide: number;
-  totalSlides: number;
 };
 
-const CustomButtonGroup = ({
-  next,
-  previous,
-  currentSlide,
-  totalSlides,
-}: CustomButtonGroupProps) => {
+const CustomButtonGroup = ({ next, previous }: CustomButtonGroupProps) => {
   const router = useRouter();
+  const currentSlide = useWorkCarouselStore((state) => state.currentSlide);
+  const totalSlides = useWorkCarouselStore((state) => state.totalSlides);
 
   const handleNext = () => {
     const newSlide = Math.min((currentSlide || 0) + 1, totalSlides - 1);
@@ -80,7 +76,9 @@ type Props = {
   children: React.ReactNode;
 };
 export default function MultiCarousel({ children }: Props) {
-  const [currentSlide, setCurrentSlide] = useState(0);
+  const setCurrentSlide = useWorkCarouselStore((state) => state.setCurrentSlide);
+  const setTotalSlides = useWorkCarouselStore((state) => state.setTotalSlides);
+  const reset = useWorkCarouselStore((state) => state.reset);
   const carouselRef = useRef<Carousel | null>(null);
 
   // children을 배열로 변환
@@ -88,6 +86,8 @@ export default function MultiCarousel({ children }: Props) {
   const totalSlides = itemsArray.length;
 
   useEffect(() => {
+    setTotalSlides(totalSlides);
+
     const searchParams = new URLSearchParams(window.location.search);
     const slideParam = parseInt(searchParams.get("slide") || "0", 10);
     const safeSlide = isNaN(slideParam) ? 0 : Math.max(0, slideParam);
@@ -99,7 +99,11 @@ export default function MultiCarousel({ children }: Props) {
         carouselRef.current.goToSlide(safeSlide);
       }
     }, 0);
-  }, []);
+
+    return () => {
+      reset();
+    };
+  }, [reset, setCurrentSlide, setTotalSlides, totalSlides]);
 
   return (
     <div className="relative">
@@ -114,8 +118,6 @@ export default function MultiCarousel({ children }: Props) {
             previous={() =>
               carouselRef.current && carouselRef.current.previous(1)
             }
-            currentSlide={currentSlide}
-            totalSlides={totalSlides}
           />
         }
         infinite={false}

--- a/docs/cache-invalidation-rules.md
+++ b/docs/cache-invalidation-rules.md
@@ -1,0 +1,54 @@
+# Cache Tag / Invalidation Rules
+
+Phase 2 목표인 **도메인별 캐시 태그 도입 + 무효화 규칙 문서화** 내용입니다.
+
+## 1) 태그 정의
+
+- `main`
+- `skill`
+- `work`
+- `resume` (resume 전체 공통)
+- `resume:descriptions`
+- `resume:certificates`
+- `resume:experiences`
+- `resume:educations`
+
+태그 상수 및 무효화 유틸은 `lib/cache-tags.ts`에서 관리합니다.
+
+## 2) 읽기(조회) 규칙
+
+조회 함수는 `unstable_cache(..., { revalidate: 60, tags: [...] })`를 사용합니다.
+
+- Main 목록 조회: `main`
+- Skill 목록 조회: `skill`
+- Work 목록 조회: `work`
+- Resume 조회:
+  - 모든 resume 조회는 공통으로 `resume`
+  - 각 세부 도메인은 `resume:*` 태그를 추가
+
+## 3) 쓰기(변경) 이후 무효화 규칙
+
+쓰기 액션(생성/수정/삭제) 완료 후 아래 규칙으로 무효화합니다.
+
+1. 변경 도메인 태그를 `revalidateTag`로 무효화
+2. 사용자 페이지도 `revalidatePath`로 함께 무효화
+3. Resume 도메인은 공통(`resume`) + 세부(`resume:*`)를 함께 무효화
+
+## 4) 구현 가이드
+
+관리자/쓰기 서버 액션에서 아래 유틸을 사용합니다.
+
+```ts
+import { revalidateDomainCache } from "@/lib/cache-tags";
+
+// 예시: work 데이터 변경 후
+revalidateDomainCache("work");
+```
+
+도메인별 경로 무효화 기준:
+
+- `main`, `skill`: `/`
+- `work`: `/work`
+- `resume`: `/resume`
+
+필요하면 상세 페이지(`resume/[slug]`) 경로도 추가로 `revalidatePath` 합니다.

--- a/hooks/use-resume-descriptions-query.ts
+++ b/hooks/use-resume-descriptions-query.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { Description } from "@/types/resume";
+import { useQuery } from "@tanstack/react-query";
+
+type DescriptionsQueryResponse = {
+  items: Description[];
+  totalCount: number;
+  totalPages: number;
+  currentPage: number;
+};
+
+export function useResumeDescriptionsQuery({
+  page,
+  query,
+  pageSize = 4,
+  initialData,
+}: {
+  page: number;
+  query: string;
+  pageSize?: number;
+  initialData?: DescriptionsQueryResponse;
+}) {
+  return useQuery<DescriptionsQueryResponse>({
+    queryKey: ["resume-descriptions", page, query, pageSize],
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        page: String(page),
+        pageSize: String(pageSize),
+      });
+
+      if (query.trim()) {
+        params.set("query", query.trim());
+      }
+
+      const response = await fetch(`/api/resume/descriptions?${params}`);
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch resume descriptions");
+      }
+
+      return response.json();
+    },
+    initialData,
+  });
+}

--- a/lib/cache-tags.ts
+++ b/lib/cache-tags.ts
@@ -1,0 +1,49 @@
+import { revalidatePath, revalidateTag } from "next/cache";
+
+export const CACHE_TAGS = {
+  main: "main",
+  skill: "skill",
+  work: "work",
+  resume: {
+    all: "resume",
+    descriptions: "resume:descriptions",
+    certificates: "resume:certificates",
+    experiences: "resume:experiences",
+    educations: "resume:educations",
+  },
+} as const;
+
+export type ResumeCacheTag =
+  (typeof CACHE_TAGS.resume)[keyof typeof CACHE_TAGS.resume];
+
+/**
+ * 데이터 변경 시 호출할 무효화 유틸.
+ * 관리자/쓰기 액션에서 도메인에 맞게 tag + path 를 함께 무효화한다.
+ */
+export function revalidateDomainCache(domain: keyof typeof CACHE_TAGS) {
+  if (domain === "main") {
+    revalidateTag(CACHE_TAGS.main);
+    revalidatePath("/");
+    return;
+  }
+
+  if (domain === "skill") {
+    revalidateTag(CACHE_TAGS.skill);
+    revalidatePath("/");
+    return;
+  }
+
+  if (domain === "work") {
+    revalidateTag(CACHE_TAGS.work);
+    revalidatePath("/work");
+    return;
+  }
+
+  // resume 도메인
+  revalidateTag(CACHE_TAGS.resume.all);
+  revalidateTag(CACHE_TAGS.resume.descriptions);
+  revalidateTag(CACHE_TAGS.resume.certificates);
+  revalidateTag(CACHE_TAGS.resume.experiences);
+  revalidateTag(CACHE_TAGS.resume.educations);
+  revalidatePath("/resume");
+}

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "react-icons": "^5.4.0",
     "react-multi-carousel": "^2.8.5",
     "react-spinners": "^0.15.0",
+    "@tanstack/react-query": "^5.90.5",
     "recharts": "^2.15.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "use-debounce": "^10.0.4",
     "uuid": "^11.0.5",
+    "zustand": "^5.0.8",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/stores/work-carousel-store.ts
+++ b/stores/work-carousel-store.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+type WorkCarouselState = {
+  currentSlide: number;
+  totalSlides: number;
+  setCurrentSlide: (currentSlide: number) => void;
+  setTotalSlides: (totalSlides: number) => void;
+  reset: () => void;
+};
+
+export const useWorkCarouselStore = create<WorkCarouselState>((set) => ({
+  currentSlide: 0,
+  totalSlides: 0,
+  setCurrentSlide: (currentSlide) => set({ currentSlide }),
+  setTotalSlides: (totalSlides) => set({ totalSlides }),
+  reset: () => set({ currentSlide: 0, totalSlides: 0 }),
+}));


### PR DESCRIPTION
### Motivation
- Improve performance and enable cache invalidation by adding domain cache tags and replacing raw fetches with cached server actions using `unstable_cache` and tag-based invalidation.
- Support client-side searching and paginated resume descriptions via a dedicated API endpoint and a React Query hook for better UX.
- Centralize client-side state for the work carousel so slide navigation and URL sync work reliably across components.
- Provide documentation for cache invalidation rules and wire up a QueryClient provider for global React Query configuration.

### Description
- Introduced `lib/cache-tags.ts` and `docs/cache-invalidation-rules.md` with cache tag constants and a `revalidateDomainCache` helper to unify tag/path invalidation.
- Replaced direct `fetch` calls in pages with server action helpers (`getMainData`, `getSkillData`, `getWorksData`, `getCertificatesData`, `getDescriptionsData`, `getExperiencesData`, `getEducationsData`) that use `unstable_cache` and appropriate cache tags.
- Added paginated/searchable resume support: created `fetchDescriptionsByQuery` in `backend/fetch-data.ts`, updated `app/api/resume/descriptions/route.ts` to parse `page`, `pageSize`, and `query` params and return paginated results, and exposed `PaginatedDescriptions` type.
- Added client-side features: `QueryProvider` (`components/providers/query-provider.tsx`) to provide a `QueryClient`, hook `use-resume-descriptions-query.ts` to fetch paginated descriptions via React Query, and updated `ResumeDescription` to support debounced search, pagination, and initial data hydration.
- Introduced a zustand store `stores/work-carousel-store.ts` and updated `components/work/multi-carousel.tsx` to sync carousel slide state with URL and store, plus cleanup on unmount.
- Added new dependencies in `package.json`: `@tanstack/react-query` and `zustand`, and `use-debounce` is used for debounced search.

### Testing
- Ran a production build with `npm run build` (`next build`) which completed successfully after the changes.
- Performed TypeScript checks as part of the build and no type errors were reported.
- No automated unit or integration tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db57f40d8c832b836ec81c80252295)