### PR TITLE
Fix duplicate fetchDescriptionsByQuery export causing build parse error

### DIFF
--- a/backend/fetch-data.ts
+++ b/backend/fetch-data.ts
@@ -272,66 +272,6 @@ export async function fetchDescriptionsByQuery({
   }
 }
 
-export async function fetchDescriptionsByQuery({
-  currentPage,
-  pageSize = PROJECTS_PER_PAGE,
-  query,
-}: {
-  currentPage: number;
-  pageSize?: number;
-  query?: string;
-}): Promise<PaginatedDescriptions> {
-  const getCachedDescriptionsByQuery = unstable_cache(
-    async (page: number, limit: number, searchQuery: string) => {
-      const offset = (page - 1) * limit;
-      const term = `%${searchQuery}%`;
-
-      const { rows: countRows } = await sql<{ count: string }>`
-        SELECT COUNT(*)::text AS count
-        FROM descriptions_contents
-        WHERE
-          (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term});
-      `;
-
-      const count = countRows[0]?.count ?? "0";
-      const totalCount = Number(count ?? "0");
-      const totalPages = Math.max(1, Math.ceil(totalCount / limit));
-
-      const { rows }: { rows: Description[] } = await sql`
-        SELECT id, title, date, performance, role, skills
-        FROM descriptions_contents
-        WHERE
-          (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term})
-        ORDER BY date DESC
-        LIMIT ${limit}
-        OFFSET ${offset};
-      `;
-
-      return {
-        items: rows,
-        totalCount,
-        totalPages,
-        currentPage: page,
-      };
-    },
-    ["resume-descriptions-by-query"],
-    {
-      revalidate: 60,
-      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
-    }
-  );
-
-  try {
-    return await getCachedDescriptionsByQuery(
-      currentPage,
-      pageSize,
-      query?.trim() ?? ""
-    );
-  } catch (error) {
-    throw new Error("Failed to fetch descriptions with query");
-  }
-}
-
 export async function fetchProjectsSlide(currentPage: number): Promise<Work[]> {
   try {
     const { rows }: { rows: Work[] } =


### PR DESCRIPTION
### Motivation
- Remove an accidental duplicate `fetchDescriptionsByQuery` export in `backend/fetch-data.ts` that caused the module parse error `Identifier 'fetchDescriptionsByQuery' has already been declared` during `next build`.

### Description
- Deleted the redundant second `export async function fetchDescriptionsByQuery(...)` block from `backend/fetch-data.ts` and retained the primary implementation that returns typed `AppError`s.

### Testing
- Ran `npm run build`; the duplicate-declaration parse error is resolved but the overall build still fails in this environment due to unrelated issues (failed Google Font fetch and missing dependencies `@tanstack/react-query` and `zustand`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf709231c832b8b8782272292dbb5)