### PR TITLE
Dedupe fetchDescriptionsByQuery and fix resume listData typing/fallback

### DIFF
--- a/backend/fetch-data.ts
+++ b/backend/fetch-data.ts
@@ -272,66 +272,6 @@ export async function fetchDescriptionsByQuery({
   }
 }
 
-export async function fetchDescriptionsByQuery({
-  currentPage,
-  pageSize = PROJECTS_PER_PAGE,
-  query,
-}: {
-  currentPage: number;
-  pageSize?: number;
-  query?: string;
-}): Promise<PaginatedDescriptions> {
-  const getCachedDescriptionsByQuery = unstable_cache(
-    async (page: number, limit: number, searchQuery: string) => {
-      const offset = (page - 1) * limit;
-      const term = `%${searchQuery}%`;
-
-      const { rows: countRows } = await sql<{ count: string }>`
-        SELECT COUNT(*)::text AS count
-        FROM descriptions_contents
-        WHERE
-          (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term});
-      `;
-
-      const count = countRows[0]?.count ?? "0";
-      const totalCount = Number(count ?? "0");
-      const totalPages = Math.max(1, Math.ceil(totalCount / limit));
-
-      const { rows }: { rows: Description[] } = await sql`
-        SELECT id, title, date, performance, role, skills
-        FROM descriptions_contents
-        WHERE
-          (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term})
-        ORDER BY date DESC
-        LIMIT ${limit}
-        OFFSET ${offset};
-      `;
-
-      return {
-        items: rows,
-        totalCount,
-        totalPages,
-        currentPage: page,
-      };
-    },
-    ["resume-descriptions-by-query"],
-    {
-      revalidate: 60,
-      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
-    }
-  );
-
-  try {
-    return await getCachedDescriptionsByQuery(
-      currentPage,
-      pageSize,
-      query?.trim() ?? ""
-    );
-  } catch (error) {
-    throw new Error("Failed to fetch descriptions with query");
-  }
-}
-
 export async function fetchProjectsSlide(currentPage: number): Promise<Work[]> {
   try {
     const { rows }: { rows: Work[] } =

--- a/components/resume/resume-description.tsx
+++ b/components/resume/resume-description.tsx
@@ -58,7 +58,9 @@ export const ResumeDescription = (props: Props) => {
 
   const totalPages = !isMobile ? queryData?.totalPages ?? 1 : 1;
 
-  const listData = !isMobile ? queryData?.items ?? [] : allDesc;
+  const listData: Description[] = !isMobile
+    ? queryData?.items ?? []
+    : allDesc ?? data;
 
   if (isLoading) {
     return <SkeletonCard />;


### PR DESCRIPTION
### Motivation
- Remove a duplicate implementation of `fetchDescriptionsByQuery` and keep the cached/AppError-backed version to avoid inconsistent error handling and duplicated code.
- Ensure the resume list rendering uses a properly typed list and falls back to the original `data` when `allDesc` is not available to avoid runtime/typing issues on mobile.

### Description
- Deleted the redundant `fetchDescriptionsByQuery` implementation that threw a generic `Error`, preserving the `unstable_cache` version that throws `AppError` and uses cache tags and revalidation settings.
- Updated `ResumeDescription` to declare `listData` as `Description[]` and changed the mobile fallback to `allDesc ?? data` so the component always has a valid items array.
- Kept existing caching parameters (`revalidate: 60`, `tags`) and error codes intact in the kept `fetchDescriptionsByQuery` implementation.

### Testing
- Ran TypeScript compilation (`tsc`) to validate types and the project build, which completed successfully.
- Ran the repository test suite (`npm test`), and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf709231c832b8b8782272292dbb5)