### PR TITLE
Remove duplicate fetchDescriptionsByQuery and simplify resume description search UI

### DIFF
--- a/backend/fetch-data.ts
+++ b/backend/fetch-data.ts
@@ -272,66 +272,6 @@ export async function fetchDescriptionsByQuery({
   }
 }
 
-export async function fetchDescriptionsByQuery({
-  currentPage,
-  pageSize = PROJECTS_PER_PAGE,
-  query,
-}: {
-  currentPage: number;
-  pageSize?: number;
-  query?: string;
-}): Promise<PaginatedDescriptions> {
-  const getCachedDescriptionsByQuery = unstable_cache(
-    async (page: number, limit: number, searchQuery: string) => {
-      const offset = (page - 1) * limit;
-      const term = `%${searchQuery}%`;
-
-      const { rows: countRows } = await sql<{ count: string }>`
-        SELECT COUNT(*)::text AS count
-        FROM descriptions_contents
-        WHERE
-          (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term});
-      `;
-
-      const count = countRows[0]?.count ?? "0";
-      const totalCount = Number(count ?? "0");
-      const totalPages = Math.max(1, Math.ceil(totalCount / limit));
-
-      const { rows }: { rows: Description[] } = await sql`
-        SELECT id, title, date, performance, role, skills
-        FROM descriptions_contents
-        WHERE
-          (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term})
-        ORDER BY date DESC
-        LIMIT ${limit}
-        OFFSET ${offset};
-      `;
-
-      return {
-        items: rows,
-        totalCount,
-        totalPages,
-        currentPage: page,
-      };
-    },
-    ["resume-descriptions-by-query"],
-    {
-      revalidate: 60,
-      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
-    }
-  );
-
-  try {
-    return await getCachedDescriptionsByQuery(
-      currentPage,
-      pageSize,
-      query?.trim() ?? ""
-    );
-  } catch (error) {
-    throw new Error("Failed to fetch descriptions with query");
-  }
-}
-
 export async function fetchProjectsSlide(currentPage: number): Promise<Work[]> {
   try {
     const { rows }: { rows: Work[] } =

--- a/components/resume/resume-description.tsx
+++ b/components/resume/resume-description.tsx
@@ -4,12 +4,7 @@ import { BoundaryResume } from "../ui/boundary-resume";
 import Pagination from "../ui/pagination";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { SkeletonCard } from "../ui/skeleton-card";
-import {
-  usePathname,
-  useRouter,
-  useSearchParams,
-} from "next/navigation";
-import { useDebouncedCallback } from "use-debounce";
+import { useSearchParams } from "next/navigation";
 import { useResumeDescriptionsQuery } from "@/hooks/use-resume-descriptions-query";
 
 type Props = {
@@ -19,8 +14,6 @@ type Props = {
 
 export const ResumeDescription = (props: Props) => {
   const { data, allDesc } = props;
-  const router = useRouter();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
 
   const isMobile = useIsMobile();
@@ -39,18 +32,6 @@ export const ResumeDescription = (props: Props) => {
     },
   });
 
-  const onSearch = useDebouncedCallback((value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-
-    if (value) {
-      params.set("query", value);
-    } else {
-      params.delete("query");
-    }
-    params.set("page", "1");
-
-    router.replace(`${pathname}?${params.toString()}`);
-  }, 300);
 
   if (isMobile === null) {
     return <SkeletonCard />;
@@ -58,7 +39,9 @@ export const ResumeDescription = (props: Props) => {
 
   const totalPages = !isMobile ? queryData?.totalPages ?? 1 : 1;
 
-  const listData = !isMobile ? queryData?.items ?? [] : allDesc;
+  const listData: Description[] = !isMobile
+    ? queryData?.items ?? []
+    : allDesc ?? data;
 
   if (isLoading) {
     return <SkeletonCard />;
@@ -66,17 +49,6 @@ export const ResumeDescription = (props: Props) => {
 
   return (
     <div className="w-full">
-      {!isMobile ? (
-        <div className="mb-4">
-          <input
-            defaultValue={currentQuery}
-            onChange={(e) => onSearch(e.target.value)}
-            placeholder="프로젝트/기술 검색"
-            aria-label="이력 검색"
-            className="w-full h-10 px-3 border border-border rounded-md bg-transparent"
-          />
-        </div>
-      ) : null}
       {!listData || listData.length === 0 ? (
         <BoundaryResume>
           <p>조건에 맞는 이력이 없습니다.</p>


### PR DESCRIPTION
### Motivation
- Consolidate the `fetchDescriptionsByQuery` implementation to keep the cached version with structured error handling and remove the older duplicate that threw a generic `Error`.
- Simplify the resume description component by removing client-side search handling and debounce logic to rely on server-provided data and props.

### Description
- Removed the duplicated implementation of `fetchDescriptionsByQuery` that used `unstable_cache` but threw a generic `Error`, leaving the improved version that throws `AppError` with `ERROR_CODES.DB_QUERY_FAILED` in `backend/fetch-data.ts`.
- Updated `components/resume/resume-description.tsx` to remove imports of `useRouter`, `usePathname`, and `useDebouncedCallback`, and removed the search input and `onSearch` debounce handler from the UI.
- Adjusted data selection in `resume-description.tsx` to compute `listData` as `!isMobile ? queryData?.items ?? [] : allDesc ?? data` and added an explicit `Description[]` type annotation to that variable.
- Kept server-side caching tags and revalidation settings for resume descriptions and kept error handling centralized via `AppError`.

### Testing
- Ran TypeScript type-check with `tsc --noEmit` and it completed successfully.
- Executed the project's automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf709231c832b8b8782272292dbb5)