### PR TITLE
refactor: 호출되지 않는 API 라우트 삭제

### DIFF
--- a/app/api/main/route.ts
+++ b/app/api/main/route.ts
@@ -1,6 +1,0 @@
-import { getMainData } from "@/backend/main-actions";
-import { withApiHandler } from "@/lib/with-api-handler";
-
-export async function GET() {
-  return withApiHandler(getMainData, "Error fetching main data:");
-}

--- a/app/api/skill/route.ts
+++ b/app/api/skill/route.ts
@@ -1,6 +1,0 @@
-import { getSkillData } from "@/backend/main-actions";
-import { withApiHandler } from "@/lib/with-api-handler";
-
-export async function GET() {
-  return withApiHandler(getSkillData, "Error fetching skill data:");
-}

--- a/app/api/work/route.ts
+++ b/app/api/work/route.ts
@@ -1,6 +1,0 @@
-import { getWorksData } from "@/backend/work-actions";
-import { withApiHandler } from "@/lib/with-api-handler";
-
-export async function GET() {
-  return withApiHandler(getWorksData, "Error fetching works data:");
-}


### PR DESCRIPTION
/api/main, /api/skill, /api/work는 어디서도 fetch되지 않아 삭제. 
/api/resume/* 는 resume/[slug]/page.tsx에서 동적으로 사용 중이므로 유지.