### PR TITLE
refactor: 미사용 /api/resume 라우트 및 generateMetadata 주석 제거

### DIFF
--- a/app/api/resume/aside/route.ts
+++ b/app/api/resume/aside/route.ts
@@ -1,6 +1,0 @@
-import { asideButtons } from "@/data/resume";
-import { withApiHandler } from "@/lib/with-api-handler";
-
-export async function GET() {
-  return withApiHandler(async () => asideButtons, "Error fetching aside button data:");
-}

--- a/app/api/resume/certificates/route.ts
+++ b/app/api/resume/certificates/route.ts
@@ -1,6 +1,0 @@
-import { getCertificatesData } from "@/backend/resume-actions";
-import { withApiHandler } from "@/lib/with-api-handler";
-
-export async function GET() {
-  return withApiHandler(getCertificatesData, "Error fetching certificate data:");
-}

--- a/app/api/resume/educations/route.ts
+++ b/app/api/resume/educations/route.ts
@@ -1,6 +1,0 @@
-import { getEducationsData } from "@/backend/resume-actions";
-import { withApiHandler } from "@/lib/with-api-handler";
-
-export async function GET() {
-  return withApiHandler(getEducationsData, "Error fetching education data:");
-}

--- a/app/api/resume/experiences/route.ts
+++ b/app/api/resume/experiences/route.ts
@@ -1,6 +1,0 @@
-import { getExperiencesData } from "@/backend/resume-actions";
-import { withApiHandler } from "@/lib/with-api-handler";
-
-export async function GET() {
-  return withApiHandler(getExperiencesData, "Error fetching experience data:");
-}

--- a/app/api/resume/titleanddescription/route.ts
+++ b/app/api/resume/titleanddescription/route.ts
@@ -1,9 +1,0 @@
-import { TitleAndDescription } from "@/data/resume";
-import { withApiHandler } from "@/lib/with-api-handler";
-
-export async function GET() {
-  return withApiHandler(
-    async () => TitleAndDescription,
-    "Error fetching title and description data:"
-  );
-}

--- a/app/resume/[slug]/page.tsx
+++ b/app/resume/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import { ResumeContents } from "@/components/resume/resume-contents";
 import { TitlesDescriptions } from "@/components/resume/titles-descriptions";
-//import { Metadata, ResolvingMetadata } from "next";
 import React from "react";
 import {
   getCertificatesData,
@@ -19,36 +18,6 @@ import { fetchProjectsPages } from "@/backend/fetch-data";
 
 type tParams = Promise<{ slug: string }>;
 type tSearchParams = Promise<{ query?: string; page?: string }>;
-
-/*
-type Props = {
-  params: Promise<{ slug: string }>;
-  searchParams: Promise<{ query?: string; page?: string }>;
-};*/
-
-/*
-export async function generateMetadata(
-  { params }: Props,
-  parent: ResolvingMetadata
-): Promise<Metadata> {
-  //const ApiUrl = process.env.PRODUCTION_URL;
-  const slug = (await params).slug;
-
-  const product = await fetchData(`${apiUrl}/api/resume/${slug}`)
-    .then((res) => res.length && res[0].meta)
-    .catch((error) => console.log(error));
-
-  // optionally access and extend (rather than replace) parent metadata
-  const previousImages = (await parent).openGraph?.images || [];
-
-  return {
-    title: product.title,
-    description: product.description,
-    openGraph: {
-      images: ["/opengraph-image.jpg", ...previousImages],
-    },
-  };
-}*/
 
 export default async function Page(
   props: { params: tParams } & { searchParams: tSearchParams }


### PR DESCRIPTION
## Summary
- `app/api/resume/` 하위 API 라우트 5개 삭제 (aside, certificates, educations, experiences, titleanddescription)
- `app/resume/[slug]/page.tsx`에서 주석 처리된 `generateMetadata` 코드 제거
- 데이터 조회가 server action으로 전환된 이후 이 라우트들은 실제로 호출되지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)