### PR TITLE
refactor: resume description 도메인에서 검색 기능 제거

### DIFF
--- a/actions/resume-descriptions.ts
+++ b/actions/resume-descriptions.ts
@@ -5,11 +5,9 @@ import { fetchDescriptionsByQuery } from "@/backend/fetch-data";
 export async function getDescriptionsByQuery({
   page,
   pageSize = 4,
-  query = "",
 }: {
   page: number;
   pageSize?: number;
-  query?: string;
 }) {
   const normalizedPage = Number.isNaN(page) || page < 1 ? 1 : page;
   const normalizedPageSize = Number.isNaN(pageSize) || pageSize < 1 ? 4 : pageSize;
@@ -17,6 +15,6 @@ export async function getDescriptionsByQuery({
   return fetchDescriptionsByQuery({
     currentPage: normalizedPage,
     pageSize: normalizedPageSize,
-    query,
+    query: "",
   });
 }

--- a/components/resume/resume-description.tsx
+++ b/components/resume/resume-description.tsx
@@ -18,11 +18,9 @@ export const ResumeDescription = (props: Props) => {
 
   const isMobile = useIsMobile();
   const currentPage = Number(searchParams.get("page")) || 1;
-  const currentQuery = searchParams.get("query") ?? "";
 
   const { data: queryData, isLoading } = useResumeDescriptionsQuery({
     page: currentPage,
-    query: currentQuery,
     pageSize: 4,
     initialData: {
       items: data,

--- a/hooks/use-resume-descriptions-query.ts
+++ b/hooks/use-resume-descriptions-query.ts
@@ -14,21 +14,19 @@ type DescriptionsQueryResponse = {
 
 export function useResumeDescriptionsQuery({
   page,
-  query,
   pageSize = 4,
   initialData,
 }: {
   page: number;
-  query: string;
   pageSize?: number;
   initialData?: DescriptionsQueryResponse;
 }) {
   return useQuery<DescriptionsQueryResponse>({
-    queryKey: ["resume-descriptions", page, query, pageSize],
+    queryKey: ["resume-descriptions", page, pageSize],
     queryFn: async () => {
       const start = performance.now();
       try {
-        const data = await getDescriptionsByQuery({ page, pageSize, query: query.trim() });
+        const data = await getDescriptionsByQuery({ page, pageSize });
         trackQueryMetric({
           key: "resume-descriptions",
           durationMs: performance.now() - start,
@@ -45,6 +43,6 @@ export function useResumeDescriptionsQuery({
       }
     },
     placeholderData: initialData,
-    enabled: !!query || page > 1,
+    enabled: page > 1,
   });
 }


### PR DESCRIPTION
## Summary

- `resume-description.tsx`에서 `currentQuery` 및 `query` 파라미터 제거
- `use-resume-descriptions-query.ts`에서 `query` 파라미터 제거, `queryKey`와 `enabled` 조건 단순화
- `resume-descriptions.ts` 서버 액션에서 `query` 파라미터 제거

## Test plan

- [ ] descriptions 페이지 정상 렌더링 확인
- [ ] 페이지네이션 정상 동작 확인 (page > 1)
- [ ] 모바일에서 전체 목록 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)