### PR TITLE
refactor: descriptions 페이지 이중 DB 쿼리 제거

### DIFF
--- a/app/resume/[slug]/page.tsx
+++ b/app/resume/[slug]/page.tsx
@@ -14,7 +14,8 @@ import {
   Experience,
   Description,
 } from "@/types/resume";
-import { fetchProjectsPages } from "@/backend/fetch-data";
+
+const DESCRIPTIONS_PAGE_SIZE = 4;
 
 type tParams = Promise<{ slug: string }>;
 type tSearchParams = Promise<{ query?: string; page?: string }>;
@@ -34,7 +35,8 @@ export default async function Page(
   if (slug === "certificates") {
     data = await getCertificatesData();
   } else if (slug === "descriptions") {
-    data = await fetchProjectsPages(currentPage);
+    const offset = (currentPage - 1) * DESCRIPTIONS_PAGE_SIZE;
+    data = AllDescription.slice(offset, offset + DESCRIPTIONS_PAGE_SIZE);
   } else if (slug === "experiences") {
     data = await getExperiencesData();
   } else if (slug === "educations") {


### PR DESCRIPTION
## Summary
- `fetchProjectsPages` 호출 제거 — `getDescriptionsData`가 이미 전체 데이터를 가져오므로 중복 쿼리였음
- 서버 컴포넌트에서 인메모리 슬라이싱(`Array.slice`)으로 현재 페이지 데이터 추출
- DB 쿼리 횟수: 2회 → 1회로 감소

## Test plan
- [ ] `/resume/descriptions` 첫 번째 페이지 정상 렌더링 확인
- [ ] 페이지네이션으로 2페이지 이동 시 정상 데이터 표시 확인
- [ ] 모바일 뷰에서 전체 목록 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)