### PR TITLE
refactor: unstable_cache 모듈 레벨 이동 및 데드코드 제거

### DIFF
--- a/backend/fetch-data.ts
+++ b/backend/fetch-data.ts
@@ -178,35 +178,45 @@ export type PaginatedDescriptions = {
   currentPage: number;
 };
 
-export async function fetchProjectsPages(
-  currentPage: number
-): Promise<Description[]> {
-  const getCachedProjectsPages = unstable_cache(
-    async (page: number) => {
-      const offset = (page - 1) * PROJECTS_PER_PAGE;
+const getCachedDescriptionsByQuery = unstable_cache(
+  async (page: number, limit: number, searchQuery: string) => {
+    const offset = (page - 1) * limit;
+    const term = `%${searchQuery}%`;
 
-      const { rows }: { rows: Description[] } =
-        await sql`SELECT id, title, date, performance, role, skills FROM descriptions_contents ORDER BY date DESC LIMIT ${PROJECTS_PER_PAGE} OFFSET ${offset};`;
-      return rows;
-    },
-    ["resume-project-pages"],
-    {
-      revalidate: 60,
-      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
-    }
-  );
+    const { rows: countRows } = await sql<{ count: string }>`
+      SELECT COUNT(*)::text AS count
+      FROM descriptions_contents
+      WHERE
+        (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term});
+    `;
 
-  try {
-    return await getCachedProjectsPages(currentPage);
-  } catch (error) {
-    throw new AppError({
-      code: ERROR_CODES.DB_QUERY_FAILED,
-      message: "Failed to fetch descriptions data",
-      status: 500,
-      details: { source: "fetchProjectsPages" },
-    });
+    const count = countRows[0]?.count ?? "0";
+    const totalCount = Number(count ?? "0");
+    const totalPages = Math.max(1, Math.ceil(totalCount / limit));
+
+    const { rows }: { rows: Description[] } = await sql`
+      SELECT id, title, date, performance, role, skills
+      FROM descriptions_contents
+      WHERE
+        (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term})
+      ORDER BY date DESC
+      LIMIT ${limit}
+      OFFSET ${offset};
+    `;
+
+    return {
+      items: rows,
+      totalCount,
+      totalPages,
+      currentPage: page,
+    };
+  },
+  ["resume-descriptions-by-query"],
+  {
+    revalidate: 60,
+    tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
   }
-}
+);
 
 export async function fetchDescriptionsByQuery({
   currentPage,
@@ -217,46 +227,6 @@ export async function fetchDescriptionsByQuery({
   pageSize?: number;
   query?: string;
 }): Promise<PaginatedDescriptions> {
-  const getCachedDescriptionsByQuery = unstable_cache(
-    async (page: number, limit: number, searchQuery: string) => {
-      const offset = (page - 1) * limit;
-      const term = `%${searchQuery}%`;
-
-      const { rows: countRows } = await sql<{ count: string }>`
-        SELECT COUNT(*)::text AS count
-        FROM descriptions_contents
-        WHERE
-          (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term});
-      `;
-
-      const count = countRows[0]?.count ?? "0";
-      const totalCount = Number(count ?? "0");
-      const totalPages = Math.max(1, Math.ceil(totalCount / limit));
-
-      const { rows }: { rows: Description[] } = await sql`
-        SELECT id, title, date, performance, role, skills
-        FROM descriptions_contents
-        WHERE
-          (${searchQuery} = '' OR title ILIKE ${term} OR skills ILIKE ${term})
-        ORDER BY date DESC
-        LIMIT ${limit}
-        OFFSET ${offset};
-      `;
-
-      return {
-        items: rows,
-        totalCount,
-        totalPages,
-        currentPage: page,
-      };
-    },
-    ["resume-descriptions-by-query"],
-    {
-      revalidate: 60,
-      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
-    }
-  );
-
   try {
     return await getCachedDescriptionsByQuery(
       currentPage,

--- a/backend/main-actions.ts
+++ b/backend/main-actions.ts
@@ -6,21 +6,17 @@ import { Main, Skill } from "@/types/main";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import { AppError, ERROR_CODES } from "@/lib/errors";
 
-/**
- * Main
- */
+const getCachedMainData = unstable_cache(
+  async () => {
+    const { rows }: { rows: Main[] } =
+      await sql`SELECT id, title, content1, content2, description, description2, description3, button, path, alt, url FROM main_contents ORDER BY path ASC;`;
+    return rows;
+  },
+  ["main-data"],
+  { revalidate: 60, tags: [CACHE_TAGS.main] }
+);
 
 export async function getMainData(): Promise<Main[]> {
-  const getCachedMainData = unstable_cache(
-    async () => {
-      const { rows }: { rows: Main[] } =
-        await sql`SELECT id, title, content1, content2, description, description2, description3, button, path, alt, url FROM main_contents ORDER BY path ASC;`;
-      return rows;
-    },
-    ["main-data"],
-    { revalidate: 60, tags: [CACHE_TAGS.main] }
-  );
-
   try {
     return await getCachedMainData();
   } catch (error) {
@@ -33,21 +29,17 @@ export async function getMainData(): Promise<Main[]> {
   }
 }
 
-/**
- * Skills
- */
+const getCachedSkillData = unstable_cache(
+  async () => {
+    const { rows }: { rows: Skill[] } =
+      await sql`SELECT id, color::int, skills::int, name, angle::int FROM skill_contents ORDER BY created_at ASC;`;
+    return rows;
+  },
+  ["skill-data"],
+  { revalidate: 60, tags: [CACHE_TAGS.skill] }
+);
 
 export async function getSkillData(): Promise<Skill[]> {
-  const getCachedSkillData = unstable_cache(
-    async () => {
-      const { rows }: { rows: Skill[] } =
-        await sql`SELECT id, color::int, skills::int, name, angle::int FROM skill_contents ORDER BY created_at ASC;`;
-      return rows;
-    },
-    ["skill-data"],
-    { revalidate: 60, tags: [CACHE_TAGS.skill] }
-  );
-
   try {
     return await getCachedSkillData();
   } catch (error) {

--- a/backend/resume-actions.ts
+++ b/backend/resume-actions.ts
@@ -11,23 +11,23 @@ import {
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import { AppError, ERROR_CODES } from "@/lib/errors";
 
-export async function getCertificatesData(): Promise<Certificate[]> {
-  const getCachedCertificatesData = unstable_cache(
-    async () => {
-      const { rows }: { rows: Certificate[] } = await sql`
-          SELECT id, date, name, authority
-          FROM certificates_contents 
-          ORDER BY date DESC;
-        `;
-      return rows;
-    },
-    ["resume-certificates-data"],
-    {
-      revalidate: 60,
-      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.certificates],
-    }
-  );
+const getCachedCertificatesData = unstable_cache(
+  async () => {
+    const { rows }: { rows: Certificate[] } = await sql`
+        SELECT id, date, name, authority
+        FROM certificates_contents
+        ORDER BY date DESC;
+      `;
+    return rows;
+  },
+  ["resume-certificates-data"],
+  {
+    revalidate: 60,
+    tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.certificates],
+  }
+);
 
+export async function getCertificatesData(): Promise<Certificate[]> {
   try {
     return await getCachedCertificatesData();
   } catch (error) {
@@ -40,20 +40,20 @@ export async function getCertificatesData(): Promise<Certificate[]> {
   }
 }
 
-export async function getDescriptionsData(): Promise<Description[]> {
-  const getCachedDescriptionsData = unstable_cache(
-    async () => {
-      const { rows }: { rows: Description[] } =
-        await sql`SELECT id, title, date, performance, role, skills FROM descriptions_contents ORDER BY date DESC ;`;
-      return rows;
-    },
-    ["resume-descriptions-data"],
-    {
-      revalidate: 60,
-      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
-    }
-  );
+const getCachedDescriptionsData = unstable_cache(
+  async () => {
+    const { rows }: { rows: Description[] } =
+      await sql`SELECT id, title, date, performance, role, skills FROM descriptions_contents ORDER BY date DESC ;`;
+    return rows;
+  },
+  ["resume-descriptions-data"],
+  {
+    revalidate: 60,
+    tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
+  }
+);
 
+export async function getDescriptionsData(): Promise<Description[]> {
   try {
     return await getCachedDescriptionsData();
   } catch (error) {
@@ -66,20 +66,20 @@ export async function getDescriptionsData(): Promise<Description[]> {
   }
 }
 
-export async function getExperiencesData(): Promise<Experience[]> {
-  const getCachedExperiencesData = unstable_cache(
-    async () => {
-      const { rows }: { rows: Experience[] } =
-        await sql`SELECT id, company, title, date, description FROM experiences_contents ORDER BY date DESC;`;
-      return rows;
-    },
-    ["resume-experiences-data"],
-    {
-      revalidate: 60,
-      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.experiences],
-    }
-  );
+const getCachedExperiencesData = unstable_cache(
+  async () => {
+    const { rows }: { rows: Experience[] } =
+      await sql`SELECT id, company, title, date, description FROM experiences_contents ORDER BY date DESC;`;
+    return rows;
+  },
+  ["resume-experiences-data"],
+  {
+    revalidate: 60,
+    tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.experiences],
+  }
+);
 
+export async function getExperiencesData(): Promise<Experience[]> {
   try {
     return await getCachedExperiencesData();
   } catch (error) {
@@ -92,20 +92,20 @@ export async function getExperiencesData(): Promise<Experience[]> {
   }
 }
 
-export async function getEducationsData(): Promise<Education[]> {
-  const getCachedEducationsData = unstable_cache(
-    async () => {
-      const { rows }: { rows: Education[] } =
-        await sql`SELECT id, school, degree, institution, date FROM educations_contents ORDER BY date DESC;`;
-      return rows;
-    },
-    ["resume-educations-data"],
-    {
-      revalidate: 60,
-      tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.educations],
-    }
-  );
+const getCachedEducationsData = unstable_cache(
+  async () => {
+    const { rows }: { rows: Education[] } =
+      await sql`SELECT id, school, degree, institution, date FROM educations_contents ORDER BY date DESC;`;
+    return rows;
+  },
+  ["resume-educations-data"],
+  {
+    revalidate: 60,
+    tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.educations],
+  }
+);
 
+export async function getEducationsData(): Promise<Education[]> {
   try {
     return await getCachedEducationsData();
   } catch (error) {

--- a/backend/work-actions.ts
+++ b/backend/work-actions.ts
@@ -6,17 +6,17 @@ import { Work } from "@/types/work";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import { AppError, ERROR_CODES } from "@/lib/errors";
 
-export async function getWorksData(): Promise<Work[]> {
-  const getCachedWorksData = unstable_cache(
-    async () => {
-      const { rows }: { rows: Work[] } =
-        await sql`SELECT id, title, description, skill, path, url, download, git, index FROM works_contents ORDER BY path DESC;`;
-      return rows;
-    },
-    ["works-data"],
-    { revalidate: 60, tags: [CACHE_TAGS.work] }
-  );
+const getCachedWorksData = unstable_cache(
+  async () => {
+    const { rows }: { rows: Work[] } =
+      await sql`SELECT id, title, description, skill, path, url, download, git, index FROM works_contents ORDER BY path DESC;`;
+    return rows;
+  },
+  ["works-data"],
+  { revalidate: 60, tags: [CACHE_TAGS.work] }
+);
 
+export async function getWorksData(): Promise<Work[]> {
   try {
     return await getCachedWorksData();
   } catch (error) {


### PR DESCRIPTION
## Summary

- 모든 `backend/` action 파일에서 `unstable_cache`를 함수 내부 생성 패턴에서 모듈 레벨 상수로 이동
- `fetchProjectsPages` 제거: `fetchDescriptionsByQuery`와 동일한 역할을 수행하면서 실제로 호출되지 않는 미사용 함수

## 변경 파일

- `backend/fetch-data.ts` — `fetchProjectsPages` 삭제, `getCachedDescriptionsByQuery` 모듈 레벨 이동
- `backend/main-actions.ts` — `getCachedMainData`, `getCachedSkillData` 모듈 레벨 이동
- `backend/resume-actions.ts` — `getCachedCertificatesData`, `getCachedDescriptionsData`, `getCachedExperiencesData`, `getCachedEducationsData` 모듈 레벨 이동
- `backend/work-actions.ts` — `getCachedWorksData` 모듈 레벨 이동

## Test plan

- [ ] `/` 홈 페이지 정상 렌더 확인
- [ ] `/work` 페이지 정상 렌더 확인
- [ ] `/resume/descriptions` 페이지 페이지네이션 정상 동작 확인
- [ ] `/resume/certificates`, `/resume/experiences`, `/resume/educations` 정상 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)