### PR TITLE
refactor: descriptions 이중 캐시 제거 및 모바일 인피니트 스크롤 적용

### DIFF
--- a/app/resume/[slug]/page.tsx
+++ b/app/resume/[slug]/page.tsx
@@ -3,10 +3,10 @@ import { TitlesDescriptions } from "@/components/resume/titles-descriptions";
 import React from "react";
 import {
   getCertificatesData,
-  getDescriptionsData,
   getEducationsData,
   getExperiencesData,
 } from "@/backend/resume-actions";
+import { fetchDescriptionsByQuery } from "@/backend/fetch-data";
 
 import {
   Certificate,
@@ -20,6 +20,12 @@ const DESCRIPTIONS_PAGE_SIZE = 4;
 type tParams = Promise<{ slug: string }>;
 type tSearchParams = Promise<{ query?: string; page?: string }>;
 
+export type DescMeta = {
+  totalCount: number;
+  totalPages: number;
+  currentPage: number;
+};
+
 export default async function Page(
   props: { params: tParams } & { searchParams: tSearchParams }
 ) {
@@ -29,14 +35,22 @@ export default async function Page(
   const currentPage = Number(searchParams?.page) || 1;
 
   let data: Description[] | Education[] | Experience[] | Certificate[] = [];
-  let allDesc: Description[] | undefined;
+  let descMeta: DescMeta | undefined;
 
   if (slug === "certificates") {
     data = await getCertificatesData();
   } else if (slug === "descriptions") {
-    allDesc = await getDescriptionsData();
-    const offset = (currentPage - 1) * DESCRIPTIONS_PAGE_SIZE;
-    data = allDesc.slice(offset, offset + DESCRIPTIONS_PAGE_SIZE);
+    const result = await fetchDescriptionsByQuery({
+      currentPage,
+      pageSize: DESCRIPTIONS_PAGE_SIZE,
+      query: "",
+    });
+    data = result.items;
+    descMeta = {
+      totalCount: result.totalCount,
+      totalPages: result.totalPages,
+      currentPage: result.currentPage,
+    };
   } else if (slug === "experiences") {
     data = await getExperiencesData();
   } else if (slug === "educations") {
@@ -46,7 +60,7 @@ export default async function Page(
   return (
     <main className="block w-full lg:w-[calc(100%-16px)] lg:ml-[16px]">
       <TitlesDescriptions slug={slug} />
-      <ResumeContents slug={slug} data={data} allDesc={allDesc} />
+      <ResumeContents slug={slug} data={data} descMeta={descMeta} />
     </main>
   );
 }

--- a/backend/resume-actions.ts
+++ b/backend/resume-actions.ts
@@ -4,7 +4,6 @@ import { sql } from "@vercel/postgres";
 import { unstable_cache } from "next/cache";
 import {
   Certificate,
-  Description,
   Experience,
   Education,
 } from "@/types/resume";
@@ -40,31 +39,6 @@ export async function getCertificatesData(): Promise<Certificate[]> {
   }
 }
 
-const getCachedDescriptionsData = unstable_cache(
-  async () => {
-    const { rows }: { rows: Description[] } =
-      await sql`SELECT id, title, date, performance, role, skills FROM descriptions_contents ORDER BY date DESC ;`;
-    return rows;
-  },
-  ["resume-descriptions-data"],
-  {
-    revalidate: 60,
-    tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
-  }
-);
-
-export async function getDescriptionsData(): Promise<Description[]> {
-  try {
-    return await getCachedDescriptionsData();
-  } catch (error) {
-    throw new AppError({
-      code: ERROR_CODES.DB_QUERY_FAILED,
-      message: "Failed to fetch descriptions data",
-      status: 500,
-      details: { source: "getDescriptionsData" },
-    });
-  }
-}
 
 const getCachedExperiencesData = unstable_cache(
   async () => {

--- a/components/resume/resume-contents.tsx
+++ b/components/resume/resume-contents.tsx
@@ -13,15 +13,16 @@ import { ResumeExperience } from "./resume-experience";
 import { ResumeDescription } from "./resume-description";
 import React from "react";
 import { ResumeCertificate } from "./resume-certificate";
+import { DescMeta } from "@/app/resume/[slug]/page";
 
 type Props = {
   slug: string;
   data: Description[] | Education[] | Experience[] | Certificate[];
-  allDesc?: Description[];
+  descMeta?: DescMeta;
 };
 
 export const ResumeContents = (props: Props) => {
-  const { slug, data, allDesc } = props;
+  const { slug, data, descMeta } = props;
 
   return (
     <section className={clsx("mb-2 lg:mb-4")}>
@@ -37,7 +38,7 @@ export const ResumeContents = (props: Props) => {
         <Suspense fallback={<SkeletonCard />}>
           <ResumeDescription
             data={data as Description[]}
-            allDesc={allDesc as Description[]}
+            descMeta={descMeta}
           />
         </Suspense>
       ) : slug === "certificates" ? (

--- a/components/resume/resume-description-desktop.tsx
+++ b/components/resume/resume-description-desktop.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Description } from "@/types/resume";
+import { BoundaryResume } from "../ui/boundary-resume";
+import Pagination from "../ui/pagination";
+import { SkeletonCard } from "../ui/skeleton-card";
+import { useSearchParams } from "next/navigation";
+import { useResumeDescriptionsQuery } from "@/hooks/use-resume-descriptions-query";
+import { DescMeta } from "@/app/resume/[slug]/page";
+
+type Props = {
+  data: Description[];
+  descMeta?: DescMeta;
+};
+
+export const ResumeDescriptionDesktop = ({ data, descMeta }: Props) => {
+  const searchParams = useSearchParams();
+  const currentPage = Number(searchParams.get("page")) || 1;
+
+  const { data: queryData, isLoading } = useResumeDescriptionsQuery({
+    page: currentPage,
+    pageSize: 4,
+    initialData: {
+      items: data,
+      totalCount: descMeta?.totalCount ?? data.length,
+      totalPages: descMeta?.totalPages ?? Math.max(1, Math.ceil(data.length / 4)),
+      currentPage: descMeta?.currentPage ?? currentPage,
+    },
+  });
+
+  if (isLoading) return <SkeletonCard />;
+
+  const items = queryData?.items ?? [];
+  const totalPages = queryData?.totalPages ?? 1;
+
+  return (
+    <div className="w-full">
+      {items.length === 0 ? (
+        <BoundaryResume>
+          <p>조건에 맞는 이력이 없습니다.</p>
+        </BoundaryResume>
+      ) : (
+        items.map((item, index) => (
+          <article key={index}>
+            <BoundaryResume>
+              <h3>{item.title}</h3>
+              <div>
+                <h4>기간</h4>
+                <p>{item.date}</p>
+              </div>
+              <div>
+                <h4>성과</h4>
+                <ul>
+                  {item.performance.map((p, i) => (
+                    <li key={i}>{p}</li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h4>역할</h4>
+                <p>{item.role}</p>
+              </div>
+              <div>
+                <h4>기술</h4>
+                <p>{item.skills}</p>
+              </div>
+            </BoundaryResume>
+          </article>
+        ))
+      )}
+      <div className="flex justify-center w-full mt-5">
+        <Pagination totalPages={totalPages} />
+      </div>
+    </div>
+  );
+};

--- a/components/resume/resume-description-mobile.tsx
+++ b/components/resume/resume-description-mobile.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Description } from "@/types/resume";
+import { BoundaryResume } from "../ui/boundary-resume";
+import { SkeletonCard } from "../ui/skeleton-card";
+import { useResumeDescriptionsInfiniteQuery } from "@/hooks/use-resume-descriptions-query";
+import { DescMeta } from "@/app/resume/[slug]/page";
+
+type Props = {
+  data: Description[];
+  descMeta?: DescMeta;
+};
+
+export const ResumeDescriptionMobile = ({ data, descMeta }: Props) => {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const { data: infiniteData, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useResumeDescriptionsInfiniteQuery({
+      pageSize: 4,
+      initialData: descMeta
+        ? {
+            items: data,
+            totalCount: descMeta.totalCount,
+            totalPages: descMeta.totalPages,
+            currentPage: 1,
+          }
+        : undefined,
+    });
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    const sentinel = sentinelRef.current;
+    if (sentinel) observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const items = infiniteData?.pages.flatMap((p) => p.items) ?? data;
+
+  return (
+    <div className="w-full">
+      {items.length === 0 ? (
+        <BoundaryResume>
+          <p>조건에 맞는 이력이 없습니다.</p>
+        </BoundaryResume>
+      ) : (
+        items.map((item, index) => (
+          <article key={index}>
+            <BoundaryResume>
+              <h3>{item.title}</h3>
+              <div>
+                <h4>기간</h4>
+                <p>{item.date}</p>
+              </div>
+              <div>
+                <h4>성과</h4>
+                <ul>
+                  {item.performance.map((p, i) => (
+                    <li key={i}>{p}</li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h4>역할</h4>
+                <p>{item.role}</p>
+              </div>
+              <div>
+                <h4>기술</h4>
+                <p>{item.skills}</p>
+              </div>
+            </BoundaryResume>
+          </article>
+        ))
+      )}
+      {isFetchingNextPage && <SkeletonCard />}
+      <div ref={sentinelRef} className="h-4" />
+    </div>
+  );
+};

--- a/components/resume/resume-description.tsx
+++ b/components/resume/resume-description.tsx
@@ -1,92 +1,25 @@
 "use client";
+
 import { Description } from "@/types/resume";
-import { BoundaryResume } from "../ui/boundary-resume";
-import Pagination from "../ui/pagination";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { SkeletonCard } from "../ui/skeleton-card";
-import { useSearchParams } from "next/navigation";
-import { useResumeDescriptionsQuery } from "@/hooks/use-resume-descriptions-query";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { ResumeDescriptionDesktop } from "./resume-description-desktop";
+import { ResumeDescriptionMobile } from "./resume-description-mobile";
+import { DescMeta } from "@/app/resume/[slug]/page";
 
 type Props = {
   data: Description[];
-  allDesc?: Description[];
+  descMeta?: DescMeta;
 };
 
-export const ResumeDescription = (props: Props) => {
-  const { data, allDesc } = props;
-  const searchParams = useSearchParams();
-
+export const ResumeDescription = ({ data, descMeta }: Props) => {
   const isMobile = useIsMobile();
-  const currentPage = Number(searchParams.get("page")) || 1;
 
-  const { data: queryData, isLoading } = useResumeDescriptionsQuery({
-    page: currentPage,
-    pageSize: 4,
-    initialData: {
-      items: data,
-      totalCount: allDesc?.length ?? data.length,
-      totalPages: Math.max(1, Math.ceil((allDesc?.length ?? data.length) / 4)),
-      currentPage,
-    },
-  });
+  if (isMobile === null) return <SkeletonCard />;
 
-
-  if (isMobile === null) {
-    return <SkeletonCard />;
-  }
-
-  const totalPages = !isMobile ? queryData?.totalPages ?? 1 : 1;
-
-  const listData: Description[] = !isMobile
-    ? queryData?.items ?? []
-    : allDesc ?? data;
-
-  if (isLoading) {
-    return <SkeletonCard />;
-  }
-
-  return (
-    <div className="w-full">
-      {!listData || listData.length === 0 ? (
-        <BoundaryResume>
-          <p>조건에 맞는 이력이 없습니다.</p>
-        </BoundaryResume>
-      ) : null}
-      {listData.map((data, index) => (
-        <article key={index}>
-          <BoundaryResume>
-            <h3>{data.title}</h3>
-            <div>
-              <h4>기간</h4>
-              <p>{data.date}</p>
-            </div>
-            <div>
-              <h4>성과</h4>
-              <ul>
-                {data.performance.map((data, index) => (
-                  <li key={index}>{data}</li>
-                ))}
-              </ul>
-            </div>
-            <div>
-              <h4>역할</h4>
-              <p> {data.role}</p>
-            </div>
-            <div>
-              <h4>기술</h4>
-              <p>{data.skills}</p>
-            </div>
-          </BoundaryResume>
-        </article>
-      ))}
-
-      {!isMobile ? (
-        <>
-          <div className="flex justify-center w-full mt-5">
-            <Pagination totalPages={totalPages} />
-          </div>
-        </>
-      ) : null}
-    </div>
+  return isMobile ? (
+    <ResumeDescriptionMobile data={data} descMeta={descMeta} />
+  ) : (
+    <ResumeDescriptionDesktop data={data} descMeta={descMeta} />
   );
 };

--- a/hooks/use-resume-descriptions-query.ts
+++ b/hooks/use-resume-descriptions-query.ts
@@ -1,11 +1,11 @@
 "use client";
 
 import { Description } from "@/types/resume";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
 import { trackQueryMetric } from "@/lib/observability";
 import { getDescriptionsByQuery } from "@/actions/resume-descriptions";
 
-type DescriptionsQueryResponse = {
+export type DescriptionsQueryResponse = {
   items: Description[];
   totalCount: number;
   totalPages: number;
@@ -44,5 +44,42 @@ export function useResumeDescriptionsQuery({
     },
     placeholderData: initialData,
     enabled: page > 1,
+  });
+}
+
+export function useResumeDescriptionsInfiniteQuery({
+  pageSize = 4,
+  initialData,
+}: {
+  pageSize?: number;
+  initialData?: DescriptionsQueryResponse;
+}) {
+  return useInfiniteQuery<DescriptionsQueryResponse>({
+    queryKey: ["resume-descriptions-infinite", pageSize],
+    queryFn: async ({ pageParam }) => {
+      const start = performance.now();
+      try {
+        const data = await getDescriptionsByQuery({ page: pageParam as number, pageSize });
+        trackQueryMetric({
+          key: "resume-descriptions-infinite",
+          durationMs: performance.now() - start,
+          status: "success",
+        });
+        return data;
+      } catch {
+        trackQueryMetric({
+          key: "resume-descriptions-infinite",
+          durationMs: performance.now() - start,
+          status: "error",
+        });
+        throw new Error("Failed to fetch resume descriptions");
+      }
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) =>
+      lastPage.currentPage < lastPage.totalPages ? lastPage.currentPage + 1 : undefined,
+    initialData: initialData
+      ? { pages: [initialData], pageParams: [1] }
+      : undefined,
   });
 }


### PR DESCRIPTION
## Summary

- `resume-descriptions-data` 캐시 엔트리 제거 — SSR에서 `getDescriptionsData()` + JS `slice()` 방식을 `fetchDescriptionsByQuery`로 통일, descriptions 캐시를 `resume-descriptions-by-query` 하나로 단일화
- `ResumeDescription`을 thin wrapper로 리팩토링 — `isMobile` 분기 후 `ResumeDescriptionDesktop` / `ResumeDescriptionMobile`로 분리 (훅 규칙 위반 없음)
- 모바일 인피니트 스크롤 구현 — `useInfiniteQuery` + `IntersectionObserver` 기반, SSR `initialData`(page 1) 주입으로 첫 로드 시 추가 네트워크 요청 없음

## Changes

| 파일 | 내용 |
|------|------|
| `app/resume/[slug]/page.tsx` | `fetchDescriptionsByQuery` 직접 호출, `DescMeta` 타입 export |
| `backend/resume-actions.ts` | `getCachedDescriptionsData` / `getDescriptionsData` 제거 |
| `components/resume/resume-contents.tsx` | `allDesc` → `descMeta` prop |
| `components/resume/resume-description.tsx` | thin wrapper (isMobile 분기만) |
| `components/resume/resume-description-desktop.tsx` | 신규 — 기존 페이지네이션 로직 |
| `components/resume/resume-description-mobile.tsx` | 신규 — 인피니트 스크롤 |
| `hooks/use-resume-descriptions-query.ts` | `useResumeDescriptionsInfiniteQuery` 훅 추가 |

## Test plan

- [ ] `/resume/descriptions` 데스크탑: 페이지네이션 정상 동작 확인
- [ ] `/resume/descriptions` 모바일: 스크롤 시 다음 페이지 자동 로드 확인
- [ ] 첫 렌더 시 SSR initialData가 사용되어 네트워크 요청 없는지 확인
- [ ] 마지막 페이지 도달 후 추가 fetch 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)