### PR TITLE
refactor: unstable_cache revalidate 60 → false 전환

### DIFF
--- a/backend/fetch-data.ts
+++ b/backend/fetch-data.ts
@@ -213,7 +213,7 @@ const getCachedDescriptionsByQuery = unstable_cache(
   },
   ["resume-descriptions-by-query"],
   {
-    revalidate: 60,
+    revalidate: false,
     tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.descriptions],
   }
 );

--- a/backend/main-actions.ts
+++ b/backend/main-actions.ts
@@ -13,7 +13,7 @@ const getCachedMainData = unstable_cache(
     return rows;
   },
   ["main-data"],
-  { revalidate: 60, tags: [CACHE_TAGS.main] }
+  { revalidate: false, tags: [CACHE_TAGS.main] }
 );
 
 export async function getMainData(): Promise<Main[]> {
@@ -36,7 +36,7 @@ const getCachedSkillData = unstable_cache(
     return rows;
   },
   ["skill-data"],
-  { revalidate: 60, tags: [CACHE_TAGS.skill] }
+  { revalidate: false, tags: [CACHE_TAGS.skill] }
 );
 
 export async function getSkillData(): Promise<Skill[]> {

--- a/backend/resume-actions.ts
+++ b/backend/resume-actions.ts
@@ -21,7 +21,7 @@ const getCachedCertificatesData = unstable_cache(
   },
   ["resume-certificates-data"],
   {
-    revalidate: 60,
+    revalidate: false,
     tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.certificates],
   }
 );
@@ -48,7 +48,7 @@ const getCachedExperiencesData = unstable_cache(
   },
   ["resume-experiences-data"],
   {
-    revalidate: 60,
+    revalidate: false,
     tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.experiences],
   }
 );
@@ -74,7 +74,7 @@ const getCachedEducationsData = unstable_cache(
   },
   ["resume-educations-data"],
   {
-    revalidate: 60,
+    revalidate: false,
     tags: [CACHE_TAGS.resume.all, CACHE_TAGS.resume.educations],
   }
 );

--- a/backend/work-actions.ts
+++ b/backend/work-actions.ts
@@ -13,7 +13,7 @@ const getCachedWorksData = unstable_cache(
     return rows;
   },
   ["works-data"],
-  { revalidate: 60, tags: [CACHE_TAGS.work] }
+  { revalidate: false, tags: [CACHE_TAGS.work] }
 );
 
 export async function getWorksData(): Promise<Work[]> {

--- a/docs/cache-invalidation-rules.md
+++ b/docs/cache-invalidation-rules.md
@@ -17,7 +17,9 @@ Phase 2 목표인 **도메인별 캐시 태그 도입 + 무효화 규칙 문서�
 
 ## 2) 읽기(조회) 규칙
 
-조회 함수는 `unstable_cache(..., { revalidate: 60, tags: [...] })`를 사용합니다.
+조회 함수는 `unstable_cache(..., { revalidate: false, tags: [...] })`를 사용합니다.
+
+> `revalidate: false` — 시간 기반 재조회 없이 태그 무효화(`revalidateTag`)만으로 캐시를 갱신합니다.
 
 - Main 목록 조회: `main`
 - Skill 목록 조회: `skill`


### PR DESCRIPTION
## Summary

- 모든 `unstable_cache` 호출의 `revalidate: 60`을 `revalidate: false`로 변경
- 태그 기반 무효화(`revalidateTag`)가 이미 구현되어 있어 시간 기반 재조회가 불필요한 DB 오버헤드를 유발하는 문제 해결
- `docs/cache-invalidation-rules.md` 문서도 변경사항에 맞게 업데이트

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `backend/main-actions.ts` | `main`, `skill` 캐시 revalidate: false |
| `backend/work-actions.ts` | `work` 캐시 revalidate: false |
| `backend/resume-actions.ts` | `certificates`, `experiences`, `educations` 캐시 revalidate: false |
| `backend/fetch-data.ts` | `descriptions` 캐시 revalidate: false |
| `docs/cache-invalidation-rules.md` | 읽기 규칙 설명 업데이트 |

## 주의사항

> `revalidate: false` 적용 이후, DB를 직접 수정한 경우 `revalidateTag` 호출 또는 재배포 없이는 캐시가 갱신되지 않습니다.

## Test plan

- [ ] 포트폴리오 각 페이지(/, /work, /resume) 정상 렌더링 확인
- [ ] 관리자 데이터 수정 후 태그 무효화로 즉시 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)